### PR TITLE
Added new infinite loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@chartisan/chartisan",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -4,7 +4,7 @@ import infinite from './infinite'
 /**
  * Determines the available loader types.
  */
-export type LoaderType = 'bar'
+export type LoaderType = 'bar' | 'infinite'
 
 /**
  * Determines the options of the loader.
@@ -49,13 +49,12 @@ const loaders = {
 export const loader = (options: LoaderOptions) => `
     <div class="chartisan-help-block">
         ${loaders[options.type](options)}
-        ${
-          options.text != ''
-            ? `
+        ${options.text != ''
+    ? `
                 <div class="chartisan-help-text" style="color: ${options.textColor};">
                     ${options.text}
                 </div>`
-            : ''
-        }
+    : ''
+  }
     </div>
 `

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -39,7 +39,7 @@ export interface LoaderOptions {
  * Determines the available loaders.
  */
 const loaders = {
-  bar,
+  bar, infinite
 }
 
 /**

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -1,4 +1,5 @@
 import bar from './bar'
+import infinite from './infinite'
 
 /**
  * Determines the available loader types.

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -49,12 +49,13 @@ const loaders = {
 export const loader = (options: LoaderOptions) => `
     <div class="chartisan-help-block">
         ${loaders[options.type](options)}
-        ${options.text != ''
-    ? `
+        ${
+          options.text != ''
+            ? `
                 <div class="chartisan-help-text" style="color: ${options.textColor};">
                     ${options.text}
                 </div>`
-    : ''
-  }
+            : ''
+        }
     </div>
 `

--- a/src/loader/infinite.ts
+++ b/src/loader/infinite.ts
@@ -1,0 +1,12 @@
+import { LoaderOptions } from './index'
+
+/**
+ * The infinite loader.
+ */
+export default ({ size, color }: LoaderOptions) => `
+    <svg width="${size[0]}" height="${size[1]}" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <path fill="none" stroke="${color}" stroke-width="8" stroke-dasharray="42 42" d="M24.3 30C11.4 30 5 43.3 5 50s6.4 20 19.3 20c19.3 0 32.1-40 51.4-40 C88.6 30 95 43.3 95 50s-6.4 20-19.3 20C56.4 70 43.6 30 24.3 30z" stroke-linecap="round">
+            <animate attributeName="stroke-dashoffset" repeatCount="indefinite" dur="1s" keyTimes="0;1" values="0;256"></animate>
+        </path>
+    </svg>
+`


### PR DESCRIPTION
New option for loader: infinite.

You can replace the default loader in your chart:

```javascript
const chart = new Chartisan({
        el: '#chart-fluxo-caixa',
        url: "", 
	loader: {
		type: 'infinite',
		size: [35, 35],
		color: '#000',
		text: 'Loading with infinite',
		textColor: '#000',
	}
});
```